### PR TITLE
feat: 초기 프로젝트 세팅 및 WebSocket 기반 실시간 주석 백엔드 구성

### DIFF
--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,11 @@
+spring.application.name=speaknote-backend
+
+spring.data.mongodb.uri=mongodb://root:secret@localhost:27017/mydatabase?authSource=admin
+
+spring.docker.compose.enabled=false
+
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+
+server.port=8080
+
+logging.level.org.example.speaknotebackend=DEBUG


### PR DESCRIPTION
### 주요 내용

- 프로젝트 기본 구조 세팅 (Spring Boot 3.4.5)
- WebSocket 설정 (`/ws/annotation`)
- GPT 비동기 처리 서비스 (`GptService`)
- MongoDB 기반 주석 블록 저장 구조 구현 (`AnnotationBlock`)
- `docker-compose.yaml`로 MongoDB, Redis 환경 구성
- `application-local.yml`에서 데이터소스 비활성화 처리_개인적으로 만들어서 gitignore 되게 해주세요

###  확인 사항

- [x] Spring Boot 정상 기동 (`./gradlew bootRun`)
- [x] MongoDB 연동 확인
- [x] WebSocket → GPT 정제 → MongoDB 저장 → 응답 흐름 확인

### 기타

- 추후 클라이언트와 메시지 포맷 JSON 통일 필요
- PDF 생성 기능 및 STT 연동은 다음 PR에서 구현 예정
